### PR TITLE
Force Number Formatters to use "." as decimal seperator

### DIFF
--- a/ColorSenseRainbow/CalculatedRGBBuilder.swift
+++ b/ColorSenseRainbow/CalculatedRGBBuilder.swift
@@ -33,11 +33,13 @@ class CalculatedRGBBuilder: ColorBuilder {
         }
         
         var numberFormatter = NSNumberFormatter()
+		numberFormatter.locale = NSLocale(localeIdentifier: "us")
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = 1  // Don't need as many digits here.
         numberFormatter.minimumFractionDigits = 1
         
         var stringFormatter = NSNumberFormatter()
+		numberFormatter.locale = NSLocale(localeIdentifier: "us")
         stringFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         
         

--- a/ColorSenseRainbow/DefaultRGBBuilder.swift
+++ b/ColorSenseRainbow/DefaultRGBBuilder.swift
@@ -30,6 +30,8 @@ class DefaultRGBBuilder: ColorBuilder {
         }
         
         var numberFormatter = NSNumberFormatter()
+		numberFormatter.locale = NSLocale(localeIdentifier: "us")
+
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = ColorBuilder.maximumFractionDigits
         numberFormatter.minimumFractionDigits = 1

--- a/ColorSenseRainbow/PredefinedColorBuilder.swift
+++ b/ColorSenseRainbow/PredefinedColorBuilder.swift
@@ -40,6 +40,8 @@ class PredefinedColorBuilder: ColorBuilder {
     private func createSwiftColor ( color : NSColor, forSearchResult : SearchResult ) -> String? {
         
         var numberFormatter = NSNumberFormatter()
+		numberFormatter.locale = NSLocale(localeIdentifier: "us")
+
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = ColorBuilder.maximumFractionDigits
         numberFormatter.minimumFractionDigits = 1
@@ -80,6 +82,8 @@ class PredefinedColorBuilder: ColorBuilder {
     private func createObjCColor ( color : NSColor, forSearchResult : SearchResult ) -> String? {
 
         var numberFormatter = NSNumberFormatter()
+		numberFormatter.locale = NSLocale(localeIdentifier: "us")
+
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = ColorBuilder.maximumFractionDigits
         


### PR DESCRIPTION
Other locales can use ',' as a seperator which will create invalid code
