### PR TITLE
Fixed problem for users with locales, which do not use a dot decimal …

### DIFF
--- a/ColorSenseRainbow/CalculatedRGBBuilder.swift
+++ b/ColorSenseRainbow/CalculatedRGBBuilder.swift
@@ -37,11 +37,12 @@ class CalculatedRGBBuilder: ColorBuilder {
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = 1  // Don't need as many digits here.
         numberFormatter.minimumFractionDigits = 1
+        numberFormatter.decimalSeparator = "." // Users, with another locales have "," separating decimals
         
         var stringFormatter = NSNumberFormatter()
 		numberFormatter.locale = NSLocale(localeIdentifier: "us")
         stringFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
-        
+        stringFormatter.decimalSeparator = numberFormatter.decimalSeparator
         
         if ( forSearchResult.tcr.numberOfRanges == 8 ) {
             if let modifiedString = processCaptureGroupInSearchResult( forSearchResult, forRangeAtIndex: 7, inText: returnString, withReplacementText: "\(color.alphaComponent)" ) {

--- a/ColorSenseRainbow/DefaultRGBBuilder.swift
+++ b/ColorSenseRainbow/DefaultRGBBuilder.swift
@@ -35,7 +35,7 @@ class DefaultRGBBuilder: ColorBuilder {
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = ColorBuilder.maximumFractionDigits
         numberFormatter.minimumFractionDigits = 1
-
+        numberFormatter.decimalSeparator = "."
         
         if ( forSearchResult.tcr.numberOfRanges == 5 ) {
             if let modifiedString = processCaptureGroupInSearchResult( forSearchResult, forRangeAtIndex: 4, inText: returnString, withReplacementText: "\(color.alphaComponent)" ) {

--- a/ColorSenseRainbow/PredefinedColorBuilder.swift
+++ b/ColorSenseRainbow/PredefinedColorBuilder.swift
@@ -45,6 +45,7 @@ class PredefinedColorBuilder: ColorBuilder {
         numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
         numberFormatter.maximumFractionDigits = ColorBuilder.maximumFractionDigits
         numberFormatter.minimumFractionDigits = 1
+        numberFormatter.decimalSeparator = "."
         
         var returnString = colorStringForType( forSearchResult.colorType )
         returnString += "Color ( red: "


### PR DESCRIPTION
…separator (e.g. Germany). With locale, the color-Strings are now correctly created with a dot syntax (not with a comma-separator)
