### PR TITLE
Quick fix for crash when searching with UIColor class method

### DIFF
--- a/ColorSenseRainbow/ColorSenseRainbow.swift
+++ b/ColorSenseRainbow/ColorSenseRainbow.swift
@@ -182,22 +182,23 @@ class ColorSenseRainbow: NSObject {
                             
                             let selectedColorRange = NSMakeRange( searchResult.tcr.range.location + lineRange.location, searchResult.tcr.range.length )
                             let selectionRectOnScreen = textView.firstRectForCharacterRange( selectedColorRange, actualRange: nil )
-                            let selectionRectInWindow = textView.window?.convertRectFromScreen( selectionRectOnScreen )
-                            let selectionRectInView = textView.convertRect( selectionRectInWindow!, fromView: nil )
-                            let colorWellRect = NSMakeRect( NSMaxX ( selectionRectInView ) - 49, NSMinY( selectionRectInView ) - selectionRectInView.size.height - 2, 50, selectionRectInView.size.height + 2 )
-                            
-                            colorWell.frame = NSIntegralRect( colorWellRect )
-                            colorWell.target = self
-                            colorWell.action = NSSelectorFromString( "colorChanged:" )
-                            
-                            addColorWell( colorWell, toTextView: textView )
-                            
-                            
-                            var colorFrame = ColorFrameView()
-                            colorFrame.frame = NSInsetRect( NSIntegralRect( selectionRectInView ), -1, -1 )
-                            colorFrame.color = borderColor
-                            
-                            addColorFrame( colorFrame, toTextView: textView )
+                            if let selectionRectInWindow = textView.window?.convertRectFromScreen( selectionRectOnScreen ) {
+                                let selectionRectInView = textView.convertRect( selectionRectInWindow, fromView: nil )
+                                let colorWellRect = NSMakeRect( NSMaxX ( selectionRectInView ) - 49, NSMinY( selectionRectInView ) - selectionRectInView.size.height - 2, 50, selectionRectInView.size.height + 2 )
+
+                                colorWell.frame = NSIntegralRect( colorWellRect )
+                                colorWell.target = self
+                                colorWell.action = NSSelectorFromString( "colorChanged:" )
+
+                                addColorWell( colorWell, toTextView: textView )
+
+
+                                var colorFrame = ColorFrameView()
+                                colorFrame.frame = NSInsetRect( NSIntegralRect( selectionRectInView ), -1, -1 )
+                                colorFrame.color = borderColor
+
+                                addColorFrame( colorFrame, toTextView: textView )
+                            }
 
                             searchResult.rangeInTextView = selectedColorRange
                             searchResults[ textView ] = searchResult


### PR DESCRIPTION
For example, search "UIColor.whiteColor()" in Xcode search navigator and then hit return.

Here's just a quick fix by coding with optional binding rather than forced unwrapping, which can be dangerous without checking if it is not nil.
